### PR TITLE
Make plain U-net available on score_sde_pytorch side

### DIFF
--- a/bin/jasmin/lotus-wrapper
+++ b/bin/jasmin/lotus-wrapper
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Wrapper script around commands for interacting with a model to queue on LOTUS on JASMIN
+
+module load gcc
+
+source ~/.bashrc
+mamba activate mv-mlde
+
+set -euo pipefail
+
+cd /home/users/vf20964/code/mlde
+
+export DERIVED_DATA=/gws/nopw/j04/bris_climdyn/henrya/bp-backups/
+export KK_SLACK_WH_URL=https://hooks.slack.com
+export WANDB_EXPERIMENT_NAME="ml-downscaling-emulator"
+
+nvidia-smi
+
+$@

--- a/bin/jasmin/queue-mlde
+++ b/bin/jasmin/queue-mlde
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Script for queueing a model job on LOTUS on JASMIN via lotus-wrapper script
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+smem=128G
+stime=1-00:00:00
+
+while getopts ":m:t:" opt; do
+  case ${opt} in
+    m)
+      smem=${OPTARG}
+      ;;
+    t)
+      stime=${OPTARG}
+      ;;
+    \? )
+      # echo "Invalid option: -${OPTARG}" 1>&2
+     ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      exit 1
+      ;;
+  esac
+done
+shift "$((OPTIND -1))"
+
+sbatch --parsable --gres=gpu:1 --partition=orchid --account=orchid --time=${stime} --mem=${smem} -- ${SCRIPT_DIR}/lotus-wrapper $@

--- a/bin/predict.py
+++ b/bin/predict.py
@@ -36,6 +36,7 @@ from ml_downscaling_emulator.score_sde_pytorch.models import utils as mutils
 
 from ml_downscaling_emulator.score_sde_pytorch.models import cncsnpp  # noqa: F401
 from ml_downscaling_emulator.score_sde_pytorch.models import cunet  # noqa: F401
+from ml_downscaling_emulator.score_sde_pytorch.models import det_cunet  # noqa: F401
 
 from ml_downscaling_emulator.score_sde_pytorch.models import (  # noqa: F401
     layerspp,  # noqa: F401

--- a/src/ml_downscaling_emulator/deterministic/configs/ukcp_local_12em_pr_unet.py
+++ b/src/ml_downscaling_emulator/deterministic/configs/ukcp_local_12em_pr_unet.py
@@ -16,9 +16,7 @@ def get_config():
     evaluate.batch_size = 64
 
     config.data = data = ml_collections.ConfigDict()
-    data.dataset_name = (
-        "bham_gcmx-4x_12em_psl-sphum4th-temp4th-vort4th_eqvt_random-season"
-    )
+    data.dataset_name = "bham64_ccpm-4x_12em_psl-sphum4th-temp4th-vort4th_pr"
     data.input_transform_key = "stan"
     data.target_transform_key = "sqrturrecen"
     data.input_transform_dataset = None

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
@@ -71,6 +71,7 @@ def get_default_configs():
   model.loc_spec_channels = 0
   model.num_scales = 1
   model.ema_rate = 0.9999
+  model.ema_disabled = False
   model.dropout = 0.1
   model.embedding_type = 'fourier'
 

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
@@ -71,7 +71,6 @@ def get_default_configs():
   model.loc_spec_channels = 0
   model.num_scales = 1
   model.ema_rate = 0.9999
-  model.ema_disabled = False
   model.dropout = 0.1
   model.embedding_type = 'fourier'
 

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/default_configs.py
@@ -27,10 +27,11 @@ def get_default_configs():
 
   # training
   config.training = training = ml_collections.ConfigDict()
-  training.batch_size = 16#128
+  training.n_epochs = 20
+  training.batch_size = 16
   training.snapshot_freq = 25
-  training.log_freq = 50
-  training.eval_freq = 1000
+  training.log_freq = 500
+  training.eval_freq = 5000
   ## store additional checkpoints for preemption in cloud computing environments
   training.snapshot_freq_for_preemption = 1000
   ## produce samples at each snapshot.
@@ -41,9 +42,6 @@ def get_default_configs():
   training.random_crop_size = 0
   training.continuous = True
   training.reduce_mean = True
-  training.n_epochs = 20
-  training.snapshot_freq = 5
-  training.eval_freq = 5000
   training.sde = ""
 
   # sampling
@@ -66,17 +64,23 @@ def get_default_configs():
 
   # model
   config.model = model = ml_collections.ConfigDict()
+  model.sigma_min = 0.01
+  model.sigma_max = 50
+  model.beta_min = 0.1
+  model.beta_max = 20.
   model.loc_spec_channels = 0
-  model.num_scales = 0
+  model.num_scales = 1
   model.ema_rate = 0.9999
+  model.dropout = 0.1
+  model.embedding_type = 'fourier'
 
   # optimization
   config.optim = optim = ml_collections.ConfigDict()
-  optim.weight_decay = 0
   optim.optimizer = 'Adam'
   optim.lr = 2e-4
   optim.beta1 = 0.9
   optim.eps = 1e-8
+  optim.weight_decay = 0
   optim.warmup = 5000
   optim.grad_clip = 1.
 

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
@@ -43,7 +43,7 @@ def get_config():
   # model
   model = config.model
   model.name = 'det_cunet'
-  model.ema_disabled = True
+  model.ema_rate = 1 # basically disables EMA
 
   # optimizer
   optim = config.optim

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
@@ -43,6 +43,7 @@ def get_config():
   # model
   model = config.model
   model.name = 'det_cunet'
+  model.ema_disabled = True
 
   # optimizer
   optim = config.optim

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_plain_unet.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2020 The Google Research Authors.
+# Modifications copyright 2024 Henry Addison
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Debug config for training a purely deterministic model.
+
+This is opposed to using a model ready for score-based denoising
+but training it in a deterministic fashion.
+"""
+
+from ml_downscaling_emulator.score_sde_pytorch.configs.deterministic.default_configs import get_default_configs
+
+def get_config():
+  config = get_default_configs()
+
+  # training
+  training = config.training
+  training.n_epochs = 100
+  training.snapshot_freq = 20
+  training.batch_size = 64
+
+  # data
+  data = config.data
+  data.dataset_name = 'bham64_ccpm-4x_12em_psl-sphum4th-temp4th-vort4th_pr'
+  data.input_transform_key = "stan"
+  data.target_transform_key = "sqrturrecen"
+  data.input_transform_dataset = None
+  data.time_inputs = False
+
+  # model
+  model = config.model
+  model.name = 'det_cunet'
+
+  # optimizer
+  optim = config.optim
+  optim.optimizer = "Adam"
+  optim.lr = 2e-4
+  optim.beta1 = 0.9
+  optim.eps = 1e-8
+  optim.weight_decay = 0
+  optim.warmup = -1 # 5000
+  optim.grad_clip = -1. # 1.
+  return config

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_tuned_plain_unet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_tuned_plain_unet.py
@@ -43,7 +43,6 @@ def get_config():
   # model
   model = config.model
   model.name = 'det_cunet'
-  model.ema_disabled = False
 
   # optimizer
   optim = config.optim

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_tuned_plain_unet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_12em_tuned_plain_unet.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2020 The Google Research Authors.
+# Modifications copyright 2024 Henry Addison
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Debug config for training a purely deterministic model.
+
+This is opposed to using a model ready for score-based denoising
+but training it in a deterministic fashion.
+"""
+
+from ml_downscaling_emulator.score_sde_pytorch.configs.deterministic.default_configs import get_default_configs
+
+def get_config():
+  config = get_default_configs()
+
+  # training
+  training = config.training
+  training.n_epochs = 100
+  training.snapshot_freq = 20
+  training.batch_size = 256
+
+  # data
+  data = config.data
+  data.dataset_name = 'bham64_ccpm-4x_12em_psl-sphum4th-temp4th-vort4th_pr'
+  data.input_transform_key = "stan"
+  data.target_transform_key = "sqrturrecen"
+  data.input_transform_dataset = None
+  data.time_inputs = False
+
+  # model
+  model = config.model
+  model.name = 'det_cunet'
+  model.ema_disabled = False
+
+  # optimizer
+  optim = config.optim
+  optim.optimizer = "Adam"
+  optim.lr = 2e-4
+  optim.beta1 = 0.9
+  optim.eps = 1e-8
+  optim.weight_decay = 0
+  optim.warmup = 5000
+  optim.grad_clip = 1.
+  return config

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_1em_cncsnpp.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_1em_cncsnpp.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+# Copyright 2020 The Google Research Authors.
+# Modifications copyright 2024 Henry Addison
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Training NCSN++ on precip data in a deterministic fashion."""
+
+from ml_downscaling_emulator.score_sde_pytorch.configs.deterministic.default_configs import get_default_configs
+
+def get_config():
+  config = get_default_configs()
+
+  # training
+  training = config.training
+  training.n_epochs = 100
+
+  # data
+  data = config.data
+  data.dataset_name = 'bham64_ccpm-4x_1em_psl-sphum4th-temp4th-vort4th_pr'
+
+  # model
+  model = config.model
+  model.name = 'cncsnpp'
+  model.loc_spec_channels = 0
+  model.dropout = 0.1
+  model.embedding_type = 'fourier'
+  model.scale_by_sigma = False
+  model.ema_rate = 0.9999
+  model.normalization = 'GroupNorm'
+  model.nonlinearity = 'swish'
+  model.nf = 128
+  model.ch_mult = (1, 2, 2, 2)
+  model.num_res_blocks = 4
+  model.attn_resolutions = (16,)
+  model.resamp_with_conv = True
+  model.conditional = True
+  model.fir = True
+  model.fir_kernel = [1, 3, 3, 1]
+  model.skip_rescale = True
+  model.resblock_type = 'biggan'
+  model.progressive = 'none'
+  model.progressive_input = 'residual'
+  model.progressive_combine = 'sum'
+  model.attention_type = 'ddpm'
+  model.embedding_type = 'positional'
+  model.init_scale = 0.
+  model.fourier_scale = 16
+  model.conv_size = 3
+
+  return config

--- a/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_plain_unet_debug.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/ukcp_local_pr_plain_unet_debug.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2020 The Google Research Authors.
+# Modifications copyright 2024 Henry Addison
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Debug config for training a purely deterministic model.
+
+This is opposed to using a model ready for score-based denoising
+but training it in a deterministic fashion.
+"""
+
+from ml_downscaling_emulator.score_sde_pytorch.configs.deterministic.default_configs import get_default_configs
+
+def get_config():
+  config = get_default_configs()
+
+  # training
+  training = config.training
+  training.n_epochs = 2
+  training.snapshot_freq = 5
+  training.eval_freq = 100
+  training.log_freq = 50
+  training.batch_size = 2
+
+  # data
+  data = config.data
+  data.dataset_name = 'debug-sample'
+  data.time_inputs = True
+
+  # model
+  model = config.model
+  model.name = 'det_cunet'
+
+  return config

--- a/src/ml_downscaling_emulator/score_sde_pytorch/models/det_cunet.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/models/det_cunet.py
@@ -1,0 +1,45 @@
+import logging
+import torch.nn as nn
+
+from ml_downscaling_emulator.unet import unet
+from . import utils
+
+def create_model(config, num_predictors):
+    if config.model.name == "u-net":
+        return unet.UNet(num_predictors, 1)
+
+from mlde_utils.training.dataset import get_variables
+
+######################################
+# !!!! DETERMINISTIC ONLY       !!!! #
+# This model does not use the time   #
+# or denoising channels at all       #
+######################################
+
+@utils.register_model(name='det_cunet')
+class DetPredNet(nn.Module):
+  """A purely deterministic plain U-Net with conditioning input."""
+
+  def __init__(self, config):
+    """Initialize a deterministic U-Net.
+    """
+    if not config.deterministic:
+      logging.warning("Only use det_cunet for deterministic approach")
+
+    super().__init__()
+    self.config = config
+
+    cond_var_channels, output_channels = list(map(len, get_variables(config.data.dataset_name)))
+    if config.data.time_inputs:
+      cond_time_channels = 3
+    else:
+      cond_time_channels = 0
+    input_channels = cond_var_channels + cond_time_channels + config.model.loc_spec_channels
+
+    self.unet = unet.UNet(input_channels, output_channels)
+
+  def forward(self, x, cond, t):
+    """Forward of conditioning inputs through the deterministic U-Net model.
+
+    Since not using the score-based, denoising approached, do not need to pass the time or the channels to be denoised to the model."""
+    return self.unet(cond)

--- a/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
@@ -124,7 +124,8 @@ def train(config, workdir):
     location_params = LocationParams(config.model.loc_spec_channels, config.data.image_size)
     location_params = location_params.to(config.device)
     location_params = torch.nn.DataParallel(location_params)
-    ema = ExponentialMovingAverage(itertools.chain(score_model.parameters(), location_params.parameters()), decay=config.model.ema_rate)
+    ema = ExponentialMovingAverage(itertools.chain(score_model.parameters(), location_params.parameters()), decay=config.model.ema_rate, disable_update=config.model.ema_disabled)
+
     optimizer = losses.get_optimizer(config, itertools.chain(score_model.parameters(), location_params.parameters()))
     state = dict(optimizer=optimizer, model=score_model, location_params=location_params, ema=ema, step=0, epoch=0)
 

--- a/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
@@ -28,7 +28,7 @@ import os
 from codetiming import Timer
 import logging
 # Keep the import below for registering all model definitions
-from .models import cunet, cncsnpp
+from .models import det_cunet, cunet, cncsnpp
 from . import losses
 from .models.location_params import LocationParams
 from . import sampling
@@ -100,15 +100,15 @@ def train(config, workdir):
   tb_dir = os.path.join(workdir, "tensorboard")
   os.makedirs(tb_dir, exist_ok=True)
 
+  run_name = os.path.basename(workdir)
   run_config = dict(
         dataset=config.data.dataset_name,
         input_transform_key=config.data.input_transform_key,
         target_transform_key=config.data.target_transform_key,
         architecture=config.model.name,
         sde=config.training.sde,
-        name=os.path.basename(workdir),
+        name=run_name,
     )
-  run_name = os.path.basename(workdir)
 
   with track_run(
         EXPERIMENT_NAME, run_name, run_config, ["score_sde"], tb_dir

--- a/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/run_lib.py
@@ -124,7 +124,7 @@ def train(config, workdir):
     location_params = LocationParams(config.model.loc_spec_channels, config.data.image_size)
     location_params = location_params.to(config.device)
     location_params = torch.nn.DataParallel(location_params)
-    ema = ExponentialMovingAverage(itertools.chain(score_model.parameters(), location_params.parameters()), decay=config.model.ema_rate, disable_update=config.model.ema_disabled)
+    ema = ExponentialMovingAverage(itertools.chain(score_model.parameters(), location_params.parameters()), decay=config.model.ema_rate)
 
     optimizer = losses.get_optimizer(config, itertools.chain(score_model.parameters(), location_params.parameters()))
     state = dict(optimizer=optimizer, model=score_model, location_params=location_params, ema=ema, step=0, epoch=0)

--- a/tests/smoke-test-det-plain-unet
+++ b/tests/smoke-test-det-plain-unet
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# config_name="ukcp_local_pr_debug"
+config_name="ukcp_local_pr_pure_deterministic_debug"
+
+workdir="output/test/deterministic/${config_name}/test-run"
+config_path="src/ml_downscaling_emulator/score_sde_pytorch/configs/deterministic/${config_name}.py"
+
+loc_spec_channels=0
+
+rm -rf ${workdir}
+WANDB_EXPERIMENT_NAME="test" python bin/main.py --workdir ${workdir} --config ${config_path} --mode train  --config.model.loc_spec_channels=${loc_spec_channels}
+
+num_samples=2
+eval_batch_size=32
+checkpoint="epoch_2"
+
+rm -rf "${workdir}/samples/${checkpoint}"
+python bin/predict.py ${workdir} --dataset debug-sample --checkpoint ${checkpoint} --batch-size ${eval_batch_size} --num-samples ${num_samples} --ensemble-member 01


### PR DESCRIPTION
Now that a way to train determinstic models using the same training loop as the score sde models, add a way to use the same u-net implementation as on the deterministic package (so eventually can remove that seperate deterministic package)

Plus add some helper scripts for testing on JASMIN