### PR TITLE
Random initization of location-specific parameters

### DIFF
--- a/src/ml_downscaling_emulator/score_sde_pytorch/models/location_params.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/models/location_params.py
@@ -5,7 +5,11 @@ class LocationParams(torch.nn.Module):
     def __init__(self, n_channels, size) -> None:
         super().__init__()
 
-        self.params = torch.nn.Parameter(torch.randn(n_channels, size, size))
+        # He initialization of weights
+        tensor = torch.randn(n_channels, size, size)
+        torch.nn.init.kaiming_normal_(tensor, mode="fan_out")
+        self.params = torch.nn.Parameter(tensor)
+
 
     def forward(self, cond):
         batch_size = cond.shape[0]

--- a/src/ml_downscaling_emulator/score_sde_pytorch/models/location_params.py
+++ b/src/ml_downscaling_emulator/score_sde_pytorch/models/location_params.py
@@ -5,7 +5,7 @@ class LocationParams(torch.nn.Module):
     def __init__(self, n_channels, size) -> None:
         super().__init__()
 
-        self.params = torch.nn.Parameter(torch.zeros(n_channels, size, size))
+        self.params = torch.nn.Parameter(torch.randn(n_channels, size, size))
 
     def forward(self, cond):
         batch_size = cond.shape[0]


### PR DESCRIPTION
Rather than initializing them all zeros, try random initialization. Landed on Kaiming from "Delving deep into rectifiers: Surpassing human-level performance on ImageNet classification" - He, K. et al. (2015) though not thoroughly tested to see if leads to material change in behaviour